### PR TITLE
fix: netcat is now netcat-traditional

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,7 +43,6 @@ class thebastion::params {
         'locales',
         'lsof',
         'mosh',
-        'netcat',
         'openssh-server',
         'pamtester',
         'rsync',
@@ -56,10 +55,13 @@ class thebastion::params {
         $_additional_packages_list = [
           'openssh-blacklist',
           'openssh-blacklist-extra',
+          'netcat'
         ]
       }
       else {
-        $_additional_packages_list = []
+        $_additional_packages_list = [
+          'netcat-traditional'
+        ]
       }
     }
     'RedHat': {

--- a/spec/classes/thebastion_spec.rb
+++ b/spec/classes/thebastion_spec.rb
@@ -84,13 +84,15 @@ describe 'thebastion' do
           it { is_expected.to contain_package('libtimedate-perl').with_ensure('installed') }
           it { is_expected.to contain_package('libwww-perl').with_ensure('installed') }
           it { is_expected.to contain_package('locales').with_ensure('installed') }
-          it { is_expected.to contain_package('netcat').with_ensure('installed') }
           it { is_expected.to contain_package('sqlite3').with_ensure('installed') }
           it { is_expected.to contain_package('xz-utils').with_ensure('installed') }
           if (os_facts[:os]['name'] == 'Ubuntu' && ['14.04', '16.04'].include?(os_facts[:os]['release']['major'])) ||
              (os_facts[:os]['name'] == 'Debian' && os_facts[:os]['release']['major'] == '8')
             it { is_expected.to contain_package('openssh-blacklist').with_ensure('installed') }
             it { is_expected.to contain_package('openssh-blacklist-extra').with_ensure('installed') }
+            it { is_expected.to contain_package('netcat').with_ensure('installed') }
+          else
+            it { is_expected.to contain_package('netcat-traditional').with_ensure('installed') }
           end
         when 'RedHat'
           it { is_expected.to contain_package('cracklib-dicts').with_ensure('installed') }


### PR DESCRIPTION
Keep installing the transitional package 'netcat' for old Debian and Ubuntu distros, but go for 'netcat-traditional' for recent ones, as the transitional package has been removed